### PR TITLE
remove nexus input positions

### DIFF
--- a/nugraph/nugraph/models/nugraph3/encoder.py
+++ b/nugraph/nugraph/models/nugraph3/encoder.py
@@ -22,7 +22,7 @@ class Encoder(nn.Module):
                  planes: tuple[str]):
         super().__init__()
         self.planar_net = nn.Linear(in_features, planar_features)
-        self.nexus_net = nn.Linear(3, nexus_features) # 3D position
+        self.nexus_features = nexus_features
         self.interaction_features = interaction_features
         self.planes = planes
 
@@ -35,7 +35,10 @@ class Encoder(nn.Module):
         """
         for p in self.planes:
             data[p].x = self.planar_net(data[p].x)
-        data["sp"].x = self.nexus_net(data["sp"].pos)
+            device = data[p].x.device
+        data["sp"].x = torch.zeros(data["sp"].num_nodes,
+                                   self.nexus_features,
+                                   device=device)
         data["evt"].x = torch.zeros(data["evt"].num_nodes,
                                     self.interaction_features,
-                                    device=data["sp"].x.device)
+                                    device=device)


### PR DESCRIPTION
remove encoding of nexus node input positions, as they are not present in all datasets and they don't seem to improve final resolution of predicted vertex