### PR TITLE
restructure graph object

### DIFF
--- a/nugraph/nugraph/models/nugraph3/core.py
+++ b/nugraph/nugraph/models/nugraph3/core.py
@@ -142,7 +142,7 @@ class NuGraphCore(nn.Module):
         # message-passing in hits
         data["hit"].x = self.checkpoint(
             self.plane_net, data["hit"].x,
-            data["hit", "plane", "hit"].edge_index)
+            data["hit", "delaunay-planar", "hit"].edge_index)
 
         # message-passing from hits to nexus
         data["sp"].x = self.checkpoint(

--- a/nugraph/nugraph/models/nugraph3/core.py
+++ b/nugraph/nugraph/models/nugraph3/core.py
@@ -74,27 +74,6 @@ class NuGraphBlock(MessagePassing):
             _, x = x
         return self.net(torch.cat((aggr_out, x), dim=1))
 
-class PlanarConv(nn.Module):
-    """
-    Planar convolution module
-    
-    Args:
-        module_dict: Dictionary containing convolution modules for each plane
-    """
-    def __init__(self, module_dict: dict[str, nn.Module]):
-        super().__init__()
-        self.net = nn.ModuleDict(module_dict)
-
-    def forward(self, data: Data) -> None:
-        """
-        PlanarConv forward pass
-        
-        Args:
-            data: Graph data object
-        """
-        for p, net in self.net.items():
-            data[p].x = net(data[p].x)
-
 class NuGraphCore(nn.Module):
     """
     NuGraph core message-passing engine

--- a/nugraph/nugraph/models/nugraph3/decoders/event.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/event.py
@@ -19,7 +19,6 @@ class EventDecoder(nn.Module):
 
     Args:
         interaction_features: Number of interaction node features
-        planes: List of detector planes
         event_classes: List of event classes
     """
     def __init__(self,

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -19,12 +19,10 @@ class InstanceDecoder(nn.Module):
     coordinates for each hit.
 
     Args:
-        planar_features: Number of planar features
+        hit_features: Number of hit node features
         instance_features: Number of instance features
-        planes: List of detector planes
     """
-    def __init__(self, planar_features: int,
-                 instance_features: int, planes: list[str]):
+    def __init__(self, hit_features: int, instance_features: int):
         super().__init__()
 
         # loss function
@@ -34,11 +32,10 @@ class InstanceDecoder(nn.Module):
         self.temp = nn.Parameter(torch.tensor(0.))
 
         # network
-        self.beta_net = nn.Linear(planar_features, 1)
-        self.coord_net = nn.Linear(planar_features, instance_features)
+        self.beta_net = nn.Linear(hit_features, 1)
+        self.coord_net = nn.Linear(hit_features, instance_features)
 
         self.dfs = []
-        self.planes = planes
 
     def forward(self, data: Data, stage: str = None) -> dict[str, Any]:
         """
@@ -50,28 +47,25 @@ class InstanceDecoder(nn.Module):
         """
 
         # run network and add output to graph object
-        for p in self.planes:
-            data[p].of = self.beta_net(data[p].x).squeeze(dim=-1).sigmoid()
-            data[p].ox = self.coord_net(data[p].x)
-            if isinstance(data, Batch):
-                data._slice_dict[p]["of"] = data[p].ptr
-                data._slice_dict[p]["ox"] = data[p].ptr
-                inc = torch.zeros(data.num_graphs, device=data[p].x.device)
-                data._inc_dict[p]["of"] = inc
-                data._inc_dict[p]["ox"] = inc
+        data["hit"].of = self.beta_net(data["hit"].x).squeeze(dim=-1).sigmoid()
+        data["hit"].ox = self.coord_net(data["hit"].x)
+        if isinstance(data, Batch):
+            data._slice_dict["hit"]["of"] = data["hit"].ptr
+            data._slice_dict["hit"]["ox"] = data["hit"].ptr
+            inc = torch.zeros(data.num_graphs, device=data["hit"].x.device)
+            data._inc_dict["hit"]["of"] = inc
+            data._inc_dict["hit"]["ox"] = inc
 
         # calculate loss
-        of = torch.cat([data[p].of for p in self.planes], dim=0)
-        ox = torch.cat([data[p].ox for p in self.planes], dim=0)
-        y = torch.cat([data[p].y_instance for p in self.planes], dim=0)
+        y = data["hit"].y_instance
         w = (-1 * self.temp).exp()
-        loss = w * self.loss((ox, of), y) + self.temp
+        loss = w * self.loss((data["hit"].ox, data["hit"].of), y) + self.temp
 
         # calculate metrics
         metrics = {}
         if stage:
             metrics[f"loss_instance/{stage}"] = loss
-            metrics[f"num_instances/{stage}"] = (of>0.1).sum().float()
+            metrics[f"num_instances/{stage}"] = (data["hit"].of>0.1).sum().float()
         if stage == "train":
             metrics["temperature/instance"] = self.temp
         if stage == "val" and isinstance(data, Batch):
@@ -89,34 +83,30 @@ class InstanceDecoder(nn.Module):
         Args:
             data: Heterodata graph object
         """
-        of = torch.cat([data[p].of for p in self.planes], dim=0)
-        ox = torch.cat([data[p].ox for p in self.planes], dim=0)
-        centers = (of > 0.1).nonzero().squeeze(1)
+        device = data["hit"].x.device
+        centers = (data["hit"].of > 0.1).nonzero().squeeze(1)
         data["particles"].num_nodes = centers.size(0)
         print(f"generating {centers.size(0)} clusters")
-        for p in self.planes:
-            print(f"  plane {p}")
-            e = data[p, "cluster", "particles"]
-            e.edge_index = torch.empty(2, 0, device=of.device)
-            e.distance = torch.empty(0,  device=of.device)
-            for i, center in enumerate(centers):
-                print(f"    instance {i+1}")
-                center_coords = ox[center]
-                dist = (data[p].ox - center_coords).square().sum(dim=1).sqrt()
-                hits = (dist < 1).nonzero().squeeze(1)
-                edge_index = torch.empty(2, hits.size(0), dtype=int, device=of.device)
-                edge_index[0] = hits
-                edge_index[1] = i
-                e.edge_index = torch.cat((e.edge_index, edge_index), dim=1)
-                e.distance = torch.cat((e.distance, dist[hits]), dim=0)
+        e = data["hit", "cluster", "particles"]
+        e.edge_index = torch.empty(2, 0, dtype=torch.long, device=device)
+        e.distance = torch.empty(0, dtype=torch.long, device=device)
+        for i, center in enumerate(centers):
+            print(f"    instance {i+1}")
+            center_coords = data["hit"].ox[center]
+            dist = (data["hit"].ox - center_coords).square().sum(dim=1).sqrt()
+            hits = (dist < 1).nonzero().squeeze(1)
+            edge_index = torch.empty(2, hits.size(0), dtype=int, device=device)
+            edge_index[0] = hits
+            edge_index[1] = i
+            e.edge_index = torch.cat((e.edge_index, edge_index), dim=1)
+            e.distance = torch.cat((e.distance, dist[hits]), dim=0)
 
-            e.edge_index=e.edge_index.long()
-            print("plane", p, "has", data[p, "cluster", "particles"].num_edges, "instance edges")
-         
-            _, instances = scatter_min(e.distance, e.edge_index[0], dim_size=data[p].num_nodes)
-            mask = instances != -1
-            instances[mask] = e.edge_index[1,instances[mask]]
-            data[p].i = instances
+        print("graph has", data["hit", "cluster", "particles"].num_edges, "instance edges")
+        
+        _, instances = scatter_min(e.distance, e.edge_index[0], dim_size=data["hit"].num_nodes)
+        mask = instances != -1
+        instances[mask] = e.edge_index[1,instances[mask]]
+        data["hit"].i = instances
 
     def draw_event_display(self, data: HeteroData) -> pd.DataFrame:
         """
@@ -125,14 +115,15 @@ class InstanceDecoder(nn.Module):
         Args:
             data: Graph data object
         """
-        coords = torch.cat([data[p].ox for p in self.planes], dim=0).cpu()
+        coords = data["hit"].ox.cpu()
         pca = PCA(n_components=2)
         c1, c2 = pca.fit_transform(coords).transpose()
-        beta = torch.cat([data[p].of for p in self.planes], dim=0).cpu()
+        beta = data["hit"].of.cpu()
         logbeta = beta.log10()
-        xy = torch.cat([data[p].pos for p in self.planes], dim=0).cpu()
-        i = torch.cat([data[p].y_instance for p in self.planes], dim=0).cpu()
-        plane = [p for p in self.planes for _ in range(data[p].num_nodes)]
+        xy = data["hit"].pos.cpu()
+        i = data["hit"].y_instance.cpu()
+        plane = data["hit"].plane.cpu()
+        plane = data["hit"].plane.cpu()
         return pd.DataFrame(dict(c1=c1, c2=c2, beta=beta, logbeta=logbeta,
                                  plane=plane, x=xy[:,0], y=xy[:,1],
                                  instance=pd.Series(i).astype(str)))

--- a/nugraph/nugraph/models/nugraph3/encoder.py
+++ b/nugraph/nugraph/models/nugraph3/encoder.py
@@ -12,19 +12,16 @@ class Encoder(nn.Module):
         planar_features: Number of planar node features
         nexus_feature: Number of nexus node features
         interaction_features: Number of interaction node features
-        planes: Tuple of planes
     """
     def __init__(self,
                  in_features: int,
                  planar_features: int,
                  nexus_features: int,
-                 interaction_features: int,
-                 planes: tuple[str]):
+                 interaction_features: int):
         super().__init__()
         self.planar_net = nn.Linear(in_features, planar_features)
         self.nexus_features = nexus_features
         self.interaction_features = interaction_features
-        self.planes = planes
 
     def forward(self, data: Data) -> None:
         """
@@ -33,12 +30,10 @@ class Encoder(nn.Module):
         Args:
             data: Graph data object
         """
-        for p in self.planes:
-            data[p].x = self.planar_net(data[p].x)
-            device = data[p].x.device
+        data["hit"].x = self.planar_net(data["hit"].x)
         data["sp"].x = torch.zeros(data["sp"].num_nodes,
                                    self.nexus_features,
-                                   device=device)
+                                   device=data["hit"].x.device)
         data["evt"].x = torch.zeros(data["evt"].num_nodes,
                                     self.interaction_features,
-                                    device=device)
+                                    device=data["hit"].x.device)

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -23,11 +23,10 @@ class NuGraph3(LightningModule):
 
     Args:
         in_features: Number of input node features
-        planar_features: Number of planar node features
+        hit_features: Number of hit node features
         nexus_features: Number of nexus node features
         interaction_features: Number of interaction node features
         instance_features: Number of instance features
-        planes: Tuple of planes
         semantic_classes: Tuple of semantic classes
         event_classes: Tuple of event classes
         num_iters: Number of message-passing iterations
@@ -40,11 +39,10 @@ class NuGraph3(LightningModule):
     """
     def __init__(self,
                  in_features: int = 4,
-                 planar_features: int = 128,
+                 hit_features: int = 128,
                  nexus_features: int = 32,
                  interaction_features: int = 32,
                  instance_features: int = 32,
-                 planes: tuple[str] = ('u','v','y'),
                  semantic_classes: tuple[str] = ('MIP','HIP','shower','michel','diffuse'),
                  event_classes: tuple[str] = ('numu','nue','nc'),
                  num_iters: int = 5,
@@ -64,20 +62,17 @@ class NuGraph3(LightningModule):
         self.nexus_features = nexus_features
         self.interaction_features = interaction_features
 
-        self.planes = planes
         self.semantic_classes = semantic_classes
         self.event_classes = event_classes
         self.num_iters = num_iters
         self.lr = lr
 
-        self.encoder = Encoder(in_features, planar_features,
-                               nexus_features, interaction_features,
-                               planes)
+        self.encoder = Encoder(in_features, hit_features,
+                               nexus_features, interaction_features)
 
-        self.core_net = NuGraphCore(planar_features,
+        self.core_net = NuGraphCore(hit_features,
                                     nexus_features,
                                     interaction_features,
-                                    planes,
                                     use_checkpointing)
 
         self.decoders = []
@@ -90,15 +85,13 @@ class NuGraph3(LightningModule):
 
         if semantic_head:
             self.semantic_decoder = SemanticDecoder(
-                planar_features,
-                planes,
+                hit_features,
                 semantic_classes)
             self.decoders.append(self.semantic_decoder)
 
         if filter_head:
             self.filter_decoder = FilterDecoder(
-                planar_features,
-                planes,
+                hit_features,
             )
             self.decoders.append(self.filter_decoder)
 
@@ -108,9 +101,8 @@ class NuGraph3(LightningModule):
 
         if instance_head:
             self.instance_decoder = InstanceDecoder(
-                planar_features,
+                hit_features,
                 instance_features,
-                planes,
             )
             self.decoders.append(self.instance_decoder)
 
@@ -255,10 +247,10 @@ class NuGraph3(LightningModule):
         model = parser.add_argument_group('model', 'NuGraph3 model configuration')
         model.add_argument('--num-iters', type=int, default=5,
                            help='Number of message-passing iterations')
-        model.add_argument('--in-feats', type=int, default=4,
+        model.add_argument('--in-feats', type=int, default=5,
                            help='Number of input node features')
-        model.add_argument('--planar-feats', type=int, default=128,
-                           help='Hidden dimensionality of planar convolutions')
+        model.add_argument('--hit-feats', type=int, default=128,
+                           help='Hidden dimensionality of hit convolutions')
         model.add_argument('--nexus-feats', type=int, default=32,
                            help='Hidden dimensionality of nexus convolutions')
         model.add_argument('--interaction-feats', type=int, default=32,
@@ -295,11 +287,10 @@ class NuGraph3(LightningModule):
         """
         return cls(
             in_features=args.in_feats,
-            planar_features=args.planar_feats,
+            hit_features=args.hit_feats,
             nexus_features=args.nexus_feats,
             interaction_features=args.interaction_feats,
             instance_features=args.instance_feats,
-            planes=nudata.planes,
             semantic_classes=nudata.semantic_classes,
             event_classes=nudata.event_classes,
             num_iters=args.num_iters,

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -29,7 +29,7 @@ class HierarchicalEdges(BaseTransform):
             edge_nexus.append(data[p, "nexus", "sp"].edge_index)
             edge_nexus[-1][0] += offset # increment only the plane node index
             del data[p, "nexus", "sp"]
-        data["hit", "plane", "hit"].edge_index = torch.cat(edge_plane, dim=1)
+        data["hit", "delaunay-planar", "hit"].edge_index = torch.cat(edge_plane, dim=1)
         data["hit", "nexus", "sp"].edge_index = torch.cat(edge_nexus, dim=1)
 
         # add plane index to feature tensor

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -48,10 +48,8 @@ class HierarchicalEdges(BaseTransform):
         lo = torch.arange(data["hit"].num_nodes, dtype=torch.long)
         hi = torch.zeros(data["hit"].num_nodes, dtype=torch.long)
         data["hit", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
-        data["evt", "owns", "hit"].edge_index = torch.stack((hi, lo), dim=0)
-
-        # add edges from nexus to plane
-        lo, hi = data["hit", "nexus", "sp"].edge_index
-        data["sp", "nexus", "hit"].edge_index = torch.stack((hi, lo), dim=0)
+        lo = torch.arange(data["sp"].num_nodes, dtype=torch.long)
+        hi = torch.zeros(data["sp"].num_nodes, dtype=torch.long)
+        data["sp", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
 
         return data

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -45,15 +45,13 @@ class HierarchicalEdges(BaseTransform):
 
         # add edges to and from event node
         data["evt"].num_nodes = 1
-        for p in self.planes + ["sp"]:
-            lo = torch.arange(data[p].num_nodes, dtype=torch.long)
-            hi = torch.zeros(data[p].num_nodes, dtype=torch.long)
-            data[p, "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
-            data["evt", "owns", p].edge_index = torch.stack((hi, lo), dim=0)
+        lo = torch.arange(data["hit"].num_nodes, dtype=torch.long)
+        hi = torch.zeros(data["hit"].num_nodes, dtype=torch.long)
+        data["hit", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
+        data["evt", "owns", "hit"].edge_index = torch.stack((hi, lo), dim=0)
 
         # add edges from nexus to plane
-        for p in self.planes:
-            lo, hi = data[p, "nexus", "sp"].edge_index
-            data["sp", "nexus", p].edge_index = torch.stack((hi, lo), dim=0)
+        lo, hi = data["hit", "nexus", "sp"].edge_index
+        data["sp", "nexus", "hit"].edge_index = torch.stack((hi, lo), dim=0)
 
         return data

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -17,6 +17,10 @@ class HierarchicalEdges(BaseTransform):
 
     def __call__(self, data: HeteroData) -> HeteroData:
 
+        # no-op if the graph data is already structured how we want
+        if hasattr(data, "hit"):
+            return data
+
         # unify planar edges
         edge_plane = []
         edge_nexus = []

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -34,8 +34,8 @@ class HierarchicalEdges(BaseTransform):
 
         # add plane index to feature tensor
         for i, p in enumerate(self.planes):
-            ip = torch.empty_like(data[p].x[:,0]).fill_(i).unsqueeze(1)
-            data[p].x = torch.cat([data[p].x, ip], dim=1)
+            data[p].plane = torch.empty_like(data[p].x[:,0], dtype=int).fill_(i)
+            data[p].x = torch.cat([data[p].x, data[p].plane.unsqueeze(1)], dim=1)
         
         # merge planar node stores
         for attr in data[self.planes[0]].node_attrs():

--- a/pynuml/pynuml/process/hitgraph.py
+++ b/pynuml/pynuml/process/hitgraph.py
@@ -191,6 +191,15 @@ class HitGraphProducer(ProcessorBase):
             edge_nexus.append(edge.long())
         data["hit", "nexus", "sp"].edge_index = torch.cat(edge_nexus, dim=1)
 
+        # add edges to event node
+        data["evt"].num_nodes = 1
+        lo = torch.arange(data["hit"].num_nodes, dtype=torch.long)
+        hi = torch.zeros(data["hit"].num_nodes, dtype=torch.long)
+        data["hit", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
+        lo = torch.arange(data["sp"].num_nodes, dtype=torch.long)
+        hi = torch.zeros(data["sp"].num_nodes, dtype=torch.long)
+        data["sp", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)
+
         # truth information
         if self.semantic_labeller:
             data["hit"].y_semantic = torch.tensor(hits['semantic_label'].fillna(-1).values).long()
@@ -202,7 +211,7 @@ class HitGraphProducer(ProcessorBase):
 
         # event label
         if self.event_labeller:
-            data['evt'].y = torch.tensor(self.event_labeller(event)).long()
+            data['evt'].y = torch.tensor(self.event_labeller(event)).long().reshape([1])
 
         # 3D vertex truth
         if self.label_vertex:

--- a/pynuml/pynuml/process/hitgraph.py
+++ b/pynuml/pynuml/process/hitgraph.py
@@ -153,48 +153,52 @@ class HitGraphProducer(ProcessorBase):
         else:
             data['sp'].num_nodes = spacepoints.shape[0]
 
-        # draw graph edges
-        for i, plane_hits in hits.groupby('local_plane'):
+        hits = hits.reset_index(names="index_2d")
 
+        # node position
+        hits[self.node_pos] *= self.pos_norm
+        data["hit"].pos = torch.tensor(hits[self.node_pos].values).float()
+
+        # node features
+        data["hit"].x = torch.tensor(hits[self.node_feats].values).float()
+
+        # node true position
+        if self.label_position:
+            data["hit"].c = torch.tensor(hits[["x_position", "y_position", "z_position"]].values).float()
+
+        # hit indices
+        data["hit"].id = torch.tensor(hits['hit_id'].values).long()
+
+        # 2D graph edges
+        data["hit", "delaunay", "hit"].edge_index = self.transform(data["hit"]).edge_index
+        edge_plane = []
+        for i, plane_hits in hits.groupby("local_plane"):
+            tmp = pyg.data.Data()
+            tmp.index_2d = torch.tensor(plane_hits.index_2d.values).long()
+            tmp.pos = torch.tensor(plane_hits[self.node_pos].values).float()
+            edge_plane.append(tmp.index_2d[self.transform(tmp).edge_index])
+        data["hit", "delaunay-planar", "hit"].edge_index = torch.cat(edge_plane, dim=1)
+
+        # 3D graph edges
+        edge_nexus = []
+        for i, plane_hits in hits.groupby("local_plane"):
             p = self.planes[i]
-            plane_hits = plane_hits.reset_index(drop=True).reset_index(names='index_2d')
+            edge = spacepoints.merge(hits[['hit_id','index_2d']].add_suffix(f'_{p}'),
+                                     on=f'hit_id_{p}',
+                                     how='inner')
+            edge = edge[[f'index_2d_{p}','index_3d']].values.transpose()
+            edge = torch.tensor(edge) if edge.size else torch.empty((2,0))
+            edge_nexus.append(edge.long())
+        data["hit", "nexus", "sp"].edge_index = torch.cat(edge_nexus, dim=1)
 
-            # node position
-            pos = torch.tensor(plane_hits[self.node_pos].values).float()
-            data[p].pos = pos * self.pos_norm[None,:]
-
-            # node features
-            data[p].x = torch.tensor(plane_hits[self.node_feats].values).float()
-
-            # node true position
-            if self.label_position:
-                data[p].c = torch.tensor(plane_hits[["x_position", "y_position", "z_position"]].values).float()
-
-            # hit indices
-            data[p].id = torch.tensor(plane_hits['hit_id'].values).long()
-
-            # 2D edges
-            data[p, 'plane', p].edge_index = self.transform(data[p]).edge_index
-
-            # 3D edges
-            edge3d = spacepoints.merge(plane_hits[['hit_id','index_2d']].add_suffix(f'_{p}'),
-                                       on=f'hit_id_{p}',
-                                       how='inner')
-            edge3d = edge3d[[f'index_2d_{p}','index_3d']].values.transpose()
-            edge3d = torch.tensor(edge3d) if edge3d.size else torch.empty((2,0))
-            data[p, 'nexus', 'sp'].edge_index = edge3d.long()
-
-            # truth information
-            if self.semantic_labeller:
-                data[p].y_semantic = torch.tensor(plane_hits['semantic_label'].fillna(-1).values).long()
-                data[p].y_instance = torch.tensor(plane_hits['instance_label'].fillna(-1).values).long()
-                if self.store_detailed_truth:
-                    data[p].g4_id = torch.tensor(plane_hits['g4_id'].fillna(-1).values).long()
-                    data[p].parent_id = torch.tensor(plane_hits['parent_id'].fillna(-1).values).long()
-                    data[p].pdg = torch.tensor(plane_hits['type'].fillna(-1).values).long()
-            if self.label_vertex:
-                vtx_2d = torch.tensor([ event[f'nu_vtx_wire_pos_{i}'], event.nu_vtx_wire_time ]).float()
-                data[p].y_vtx = vtx_2d * self.pos_norm[None,:]
+        # truth information
+        if self.semantic_labeller:
+            data["hit"].y_semantic = torch.tensor(hits['semantic_label'].fillna(-1).values).long()
+            data["hit"].y_instance = torch.tensor(hits['instance_label'].fillna(-1).values).long()
+            if self.store_detailed_truth:
+                data["hit"].g4_id = torch.tensor(hits['g4_id'].fillna(-1).values).long()
+                data["hit"].parent_id = torch.tensor(hits['parent_id'].fillna(-1).values).long()
+                data["hit"].pdg = torch.tensor(hits['type'].fillna(-1).values).long()
 
         # event label
         if self.event_labeller:


### PR DESCRIPTION
restructure the graph data object to unify the planar hit node stores into a single node store. the connectivity of the graph edges remains the same. since the hit nodes are in a single node store, we no longer need `HeteroConv` for message-passing, so the model architecture has been simplified accordingly.

the graph restructure is implemented in the hierarchical feature transform, so existing graph objects will be updated to the new structure. graph processing in pynuml has also been updated, so future processing runs will produce this structure natively.

closes #84