### PR TITLE
improvements to clustering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/notebooks/make-test-file.ipynb
+++ b/notebooks/make-test-file.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "749149dd-b4f2-4fb8-9897-9cadd42128d8",
+   "metadata": {},
+   "source": [
+    "### Set autoreloading\n",
+    "This extension will automatically update with any changes to packages in real time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1020db2-2ee5-49cb-99ac-fb28a348e6e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07e31949-fb8c-437d-a7e1-775679d0730b",
+   "metadata": {},
+   "source": [
+    "### Import packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e758be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tqdm\n",
+    "import numpy as np\n",
+    "import h5py\n",
+    "import pynuml\n",
+    "import nugraph as ng"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5dc3df9",
+   "metadata": {},
+   "source": [
+    "### Configure arguments\n",
+    "Name of input file and number of events to write to summary file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c605ea3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FILE = os.path.expandvars(\"$NUGRAPH_DATA/uboone-opendata/uboone-opendata-e5fac1ac.evt.h5\")\n",
+    "NUM_EVTS = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50efba67",
+   "metadata": {},
+   "source": [
+    "### Get list of indices\n",
+    "Loop over events in file and construct a list of events that will produce valid graphs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1f5a7f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ids = {}\n",
+    "f = pynuml.io.File(FILE)\n",
+    "processor = pynuml.process.HitGraphProducer(file=f)\n",
+    "for i, evt in enumerate(f):\n",
+    "    if not evt:\n",
+    "        continue\n",
+    "    name, data = processor(evt)\n",
+    "    if data:\n",
+    "        ids[i] = evt.event_id\n",
+    "    if len(ids) == NUM_EVTS:\n",
+    "        break\n",
+    "del f"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "652a04c7",
+   "metadata": {},
+   "source": [
+    "### Extract raw arrays\n",
+    "Loop over datasets in input HDF5 file, and extract arrays for the events selected above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7baea8d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with h5py.File(FILE) as f:\n",
+    "\n",
+    "    # initialize empty array dictionary\n",
+    "    keys = []\n",
+    "    arrays = {}\n",
+    "    for group in f.keys():\n",
+    "        for key in f[group].keys():\n",
+    "            if \".seq\" in key:\n",
+    "                continue\n",
+    "            keys.append(f\"{group}/{key}\")\n",
+    "            arrays[keys[-1]] = []\n",
+    "\n",
+    "    # read arrays from file\n",
+    "    for i, event_id in tqdm.tqdm(ids.items()):\n",
+    "        mask = {g: ((f[g][\"event_id.seq\"][()] == i)[:, 0]).nonzero() for g in f.keys()}\n",
+    "        for key in keys:\n",
+    "            g, k = key.split(\"/\")\n",
+    "            arrays[key].append(f[key][mask[g]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb2e39c1",
+   "metadata": {},
+   "source": [
+    "### Write to summary file\n",
+    "Combine arrays across summary events, and write them to a new summary file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29be0359",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with h5py.File(FILE[:-7]+\".test.h5\", \"w\") as f:\n",
+    "    for key in keys:\n",
+    "        f[key] = np.concatenate(arrays[key])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1589ea4a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/plot.ipynb
+++ b/notebooks/plot.ipynb
@@ -36,6 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import nugraph as ng\n",
     "import pynuml\n",
     "import torch"
@@ -47,7 +48,7 @@
    "metadata": {},
    "source": [
     "### Configure data module\n",
-    "Declare a data module. Depending on where you're working, you should edit the data path below to point to a valid data location."
+    "Set up nugraph environment and then declare a data module. If you're working on a standard cluster, the data file location should be configured automatically. If not, you'll need to configure it manually."
    ]
   },
   {
@@ -57,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nudata = ng.data.H5DataModule(data_path='/raid/nugraph/uboone-opendata/uboone-opendata.gnn.h5',\n",
-    "                              batch_size=64)"
+    "ng.setup_env()\n",
+    "nudata = ng.data.H5DataModule()"
    ]
   },
   {
@@ -77,7 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = ng.models.NuGraph3.load_from_checkpoint('/raid/nugraph/uboone-opendata/hierarchical.ckpt', map_location='cpu')\n",
+    "ckpt = os.path.expandvars(\"$NUGRAPH_DATA/uboone-opendata/hierarchical.ckpt\")\n",
+    "model = ng.models.NuGraph3.load_from_checkpoint(ckpt, map_location=\"cpu\")\n",
     "model.freeze()"
    ]
   },
@@ -397,6 +399,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/plot.ipynb
+++ b/notebooks/plot.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "source": [
     "### Configure data module\n",
-    "Set up nugraph environment and then declare a data module. If you're working on a standard cluster, the data file location should be configured automatically. If not, you'll need to configure it manually."
+    "Declare a data module. If you're working on a standard cluster, the data file location should be configured automatically. If not, you'll need to configure it manually."
    ]
   },
   {
@@ -58,7 +58,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ng.setup_env()\n",
     "nudata = ng.data.H5DataModule()"
    ]
   },
@@ -399,18 +398,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -36,8 +36,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from pathlib import Path\n",
     "import nugraph as ng\n",
     "import pytorch_lightning as pl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52b3e618",
+   "metadata": {},
+   "source": [
+    "### Set up nugraph environment\n",
+    "\n",
+    "This function will set up your environment (home directory, data directory and output log directory). If the `NUGRAPH_DIR`, `NUGRAPH_DATA` or `NUGRAPH_LOG` environment variables are set, they will be used – if not, it will detect your current host and attempt to automatically configure them. If your environment fails to configure automatically, you can either set the environment variables in this code block by declaring `os.environ[\"NUGRAPH_DIR\"] = \"/your/path\"` etc, or add your host to the `NUGRAPH_ENV` dictionary in `nugraph/util/scriptutils.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3039e416",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ng.setup_env()"
    ]
   },
   {
@@ -56,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nudata = ng.data.H5DataModule(data_path='/raid/nugraph/uboone-opendata/uboone-opendata.gnn.h5', batch_size=64)"
+    "nudata = ng.data.H5DataModule(data_path='$NUGRAPH_DATA/uboone-opendata/uboone-opendata.gnn.h5', batch_size=64)"
    ]
   },
   {
@@ -110,9 +132,14 @@
    "outputs": [],
    "source": [
     "name = \"test\"\n",
-    "version = \"test\"\n",
-    "logger = pl.loggers.WandbLogger(save_dir='/raid/vhewes/logs', project=name, name=version)\n",
-    "callbacks = [ pl.callbacks.LearningRateMonitor(logging_interval='step') ]"
+    "logdir = Path(os.environ[\"NUGRAPH_LOG\"])/name\n",
+    "logdir.mkdir(parents=True, exist_ok=True)\n",
+    "logger = pl.loggers.WandbLogger(save_dir=logdir, project=\"nugraph3\", name=\"test\",\n",
+    "                                log_model=\"all\")\n",
+    "callbacks = [\n",
+    "    pl.callbacks.LearningRateMonitor(logging_interval=\"step\"),\n",
+    "    pl.callbacks.ModelCheckpoint(monitor=\"loss/val\", mode=\"min\"),\n",
+    "]"
    ]
   },
   {

--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -111,8 +111,7 @@
    "source": [
     "name = \"test\"\n",
     "version = \"test\"\n",
-    "logger = pl.loggers.WandbLogger(save_dir='/raid/vhewes/logs', project=name,\n",
-    "                                name=version, version=version)\n",
+    "logger = pl.loggers.WandbLogger(save_dir='/raid/vhewes/logs', project=name, name=version)\n",
     "callbacks = [ pl.callbacks.LearningRateMonitor(logging_interval='step') ]"
    ]
   },

--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -44,26 +44,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52b3e618",
-   "metadata": {},
-   "source": [
-    "### Set up nugraph environment\n",
-    "\n",
-    "This function will set up your environment (home directory, data directory and output log directory). If the `NUGRAPH_DIR`, `NUGRAPH_DATA` or `NUGRAPH_LOG` environment variables are set, they will be used – if not, it will detect your current host and attempt to automatically configure them. If your environment fails to configure automatically, you can either set the environment variables in this code block by declaring `os.environ[\"NUGRAPH_DIR\"] = \"/your/path\"` etc, or add your host to the `NUGRAPH_ENV` dictionary in `nugraph/util/scriptutils.py`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3039e416",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ng.setup_env()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "59d08add-2aa1-4aa1-a4b9-20080cbc96dc",
    "metadata": {},
    "source": [
@@ -78,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nudata = ng.data.H5DataModule(data_path='$NUGRAPH_DATA/uboone-opendata/uboone-opendata.gnn.h5', batch_size=64)"
+    "nudata = ng.data.H5DataModule()"
    ]
   },
   {

--- a/nugraph/nugraph/__init__.py
+++ b/nugraph/nugraph/__init__.py
@@ -4,4 +4,5 @@ __version__ = "24.7.dev1"
 from . import data
 from . import models
 from . import util
-from .util import setup_env
+
+util.setup_env()

--- a/nugraph/nugraph/__init__.py
+++ b/nugraph/nugraph/__init__.py
@@ -4,3 +4,4 @@ __version__ = "24.7.dev1"
 from . import data
 from . import models
 from . import util
+from .util import setup_env

--- a/nugraph/nugraph/data/H5DataModule.py
+++ b/nugraph/nugraph/data/H5DataModule.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 import warnings
 
+import os
 import sys
 import h5py
 import tqdm
@@ -28,7 +29,7 @@ class H5DataModule(LightningDataModule):
         # so we silence PyTorch Lightning's warnings
         warnings.filterwarnings("ignore", ".*does not have many workers.*")
 
-        self.filename = data_path
+        self.filename = os.path.expandvars(data_path)
         self.batch_size = batch_size
         if shuffle != 'random' and shuffle != 'balance':
             print('shuffle argument must be "random" or "balance".')

--- a/nugraph/nugraph/data/H5DataModule.py
+++ b/nugraph/nugraph/data/H5DataModule.py
@@ -15,11 +15,14 @@ from pytorch_lightning import LightningDataModule
 from ..data import H5Dataset, BalanceSampler
 from ..util import PositionFeatures, FeatureNormMetric, FeatureNorm, HierarchicalEdges, EventLabels
 
+DEFAULT_DATA = ("$NUGRAPH_DATA/uboone-opendata/"
+                "uboone-opendata-19be46d89d0f22f5a78641d724c1fedd.gnn.h5")
+
 class H5DataModule(LightningDataModule):
     """PyTorch Lightning data module for neutrino graph data."""
     def __init__(self,
-                 data_path: str,
-                 batch_size: int,
+                 data_path: str = "auto",
+                 batch_size: int = 64,
                  shuffle: str = 'random',
                  balance_frac: float = 0.1,
                  prepare: bool = False):
@@ -29,6 +32,8 @@ class H5DataModule(LightningDataModule):
         # so we silence PyTorch Lightning's warnings
         warnings.filterwarnings("ignore", ".*does not have many workers.*")
 
+        if data_path == "auto":
+            data_path = DEFAULT_DATA
         self.filename = os.path.expandvars(data_path)
         self.batch_size = batch_size
         if shuffle != 'random' and shuffle != 'balance':
@@ -185,8 +190,7 @@ class H5DataModule(LightningDataModule):
     @staticmethod
     def add_data_args(parser: ArgumentParser) -> ArgumentParser:
         data = parser.add_argument_group('data', 'Data module configuration')
-        data.add_argument('--data-path', type=str,
-                          default='/raid/uboone/NuGraph2/NG2-paper.gnn.h5',
+        data.add_argument('--data-path', type=str, default="auto",
                           help='Location of input data file')
         data.add_argument('--batch-size', type=int, default=64,
                           help='Size of each batch of graphs')

--- a/nugraph/nugraph/models/nugraph3/core.py
+++ b/nugraph/nugraph/models/nugraph3/core.py
@@ -102,7 +102,6 @@ class NuGraphCore(nn.Module):
         # message-passing from planar nodes to nexus nodes
         self.plane_to_nexus = NuGraphBlock(hit_features, nexus_features,
                                            nexus_features)
-        
 
         # message-passing from nexus nodes to interaction nodes
         self.nexus_to_interaction = NuGraphBlock(nexus_features,

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -1,13 +1,11 @@
 """NuGraph3 instance decoder"""
 from typing import Any
-import pathlib
 import torch
 from torch import nn
 from torchmetrics.clustering import AdjustedRandScore
 from torch_scatter import scatter_min
-from torch_geometric.data import Batch, HeteroData
+from torch_geometric.data import Batch
 from torch_geometric.utils import cumsum
-from pytorch_lightning.loggers import TensorBoardLogger
 from ....util import ObjCondensationLoss
 from ..types import Data, N_IT, N_IP, E_H_IT, E_H_IP
 

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -129,3 +129,13 @@ class InstanceDecoder(nn.Module):
         e.edge_index = (dist < 1).nonzero().transpose(0, 1).detach()
         e.distance = dist[e.edge_index[0], e.edge_index[1]].detach()
         return data
+
+    def on_epoch_end(self, logger: "WandbLogger", stage: str, epoch: int) -> None:
+        """
+        NuGraph3 decoder end-of-epoch callback function
+
+        Args:
+            logger: Tensorboard logger object
+            stage: Training stage
+            epoch: Training epoch index
+        """

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -107,6 +107,7 @@ class InstanceDecoder(nn.Module):
         y = torch.full_like(data["hit"].y_semantic, -1)
         i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
         y[i] = j
+        data["hit"].y_instance = y
         loss = (-1 * self.temp).exp() * self.loss(data, y) + self.temp
 
         # calculate metrics

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -60,7 +60,7 @@ class InstanceDecoder(LightningModule):
             data._inc_dict["hit"]["ox"] = data._inc_dict["hit"]["x"]
 
         # materialize instances
-        materialize = (data["hit"].of > 0.1).sum() < 2000
+        materialize = True
         if materialize:
             # form instances across batch
             imask = data["hit"].of > 0.1

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -103,11 +103,11 @@ class InstanceDecoder(nn.Module):
             data._inc_dict["hit"]["i"] = data._inc_dict["hit"]["x"]
 
         # calculate loss
-        if isinstance(data, Batch):
-            loss = torch.tensor([self.loss_wrap(d) for d in data.to_data_list()]).mean()
-        else:
-            loss = self.loss_wrap(data)
-        loss = (-1 * self.temp).exp() * loss + self.temp
+        y = torch.full_like(data["hit"].y_semantic, -1)
+        i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
+        y[i] = j
+        w = (-1 * self.temp).exp()
+        loss = w * self.loss((data["hit"].ox, data["hit"].of), y) + self.temp
 
         # calculate metrics
         metrics = {}
@@ -126,18 +126,6 @@ class InstanceDecoder(nn.Module):
                 self.dfs.append(self.draw_event_display(d))
 
         return loss, metrics
-
-    def loss_wrap(self, data: HeteroData) -> torch.Tensor:
-        """
-        Extract tensors from data object and calculate loss
-
-        Args:
-            data:Heterodata graph object
-        """
-        y = torch.full_like(data["hit"].y_semantic, -1)
-        i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
-        y[i] = j
-        return self.loss((data["hit"].ox, data["hit"].of), y)
 
     def materialize(self, data: Data) -> None:
         """

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -72,7 +72,9 @@ class InstanceDecoder(nn.Module):
                 self.instance_decoder.materialize(data)
 
         # calculate loss
-        y = data["hit"].y_instance
+        y = torch.empty_like(data["hit"].y_semantic).fill_(-1)
+        i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
+        y[i] = j
         w = (-1 * self.temp).exp()
         loss = w * self.loss((data["hit"].ox, data["hit"].of), y) + self.temp
 

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -103,11 +103,11 @@ class InstanceDecoder(nn.Module):
             data._inc_dict["hit"]["i"] = data._inc_dict["hit"]["x"]
 
         # calculate loss
-        y = torch.full_like(data["hit"].y_semantic, -1)
-        i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
-        y[i] = j
-        w = (-1 * self.temp).exp()
-        loss = w * self.loss((data["hit"].ox, data["hit"].of), y) + self.temp
+        if isinstance(data, Batch):
+            loss = torch.tensor([self.loss_wrap(d) for d in data.to_data_list()]).mean()
+        else:
+            loss = self.loss_wrap(data)
+        loss = (-1 * self.temp).exp() * loss + self.temp
 
         # calculate metrics
         metrics = {}
@@ -126,6 +126,18 @@ class InstanceDecoder(nn.Module):
                 self.dfs.append(self.draw_event_display(d))
 
         return loss, metrics
+
+    def loss_wrap(self, data: HeteroData) -> torch.Tensor:
+        """
+        Extract tensors from data object and calculate loss
+
+        Args:
+            data:Heterodata graph object
+        """
+        y = torch.full_like(data["hit"].y_semantic, -1)
+        i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
+        y[i] = j
+        return self.loss((data["hit"].ox, data["hit"].of), y)
 
     def materialize(self, data: Data) -> None:
         """

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -72,7 +72,7 @@ class InstanceDecoder(nn.Module):
                 self.instance_decoder.materialize(data)
 
         # calculate loss
-        y = torch.empty_like(data["hit"].y_semantic).fill_(-1)
+        y = torch.full_like(data["hit"].y_semantic, -1)
         i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
         y[i] = j
         w = (-1 * self.temp).exp()

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -7,7 +7,6 @@ from torchmetrics.clustering import AdjustedRandScore
 from torch_scatter import scatter_min
 from torch_geometric.data import Batch, HeteroData
 from pytorch_lightning.loggers import TensorBoardLogger
-from torch_scatter import scatter_min
 import pandas as pd
 from sklearn.decomposition import PCA
 import plotly.express as px

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -82,7 +82,7 @@ class InstanceDecoder(nn.Module):
             metrics[f"instance/loss-{stage}"] = loss
             if materialize:
                 x = data["hit"].i
-                metrics[f"instance/adjusted-rand-{stage}"] = self.rand(x, y)   
+                metrics[f"instance/adjusted-rand-{stage}"] = self.rand(x, y)
         if stage == "train":
             metrics["temperature/instance"] = self.temp
 
@@ -116,7 +116,7 @@ class InstanceDecoder(nn.Module):
             edge_index[1] = i
             e.edge_index = torch.cat((e.edge_index, edge_index), dim=1)
             e.distance = torch.cat((e.distance, dist[hits]), dim=0)
-        
+
         _, instances = scatter_min(e.distance, e.edge_index[0], dim_size=data["hit"].num_nodes)
         mask = instances < e.num_edges
         instances[~mask] = -1

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -106,8 +106,7 @@ class InstanceDecoder(nn.Module):
         y = torch.full_like(data["hit"].y_semantic, -1)
         i, j = data["hit", "cluster-truth", "particle-truth"].edge_index
         y[i] = j
-        w = (-1 * self.temp).exp()
-        loss = w * self.loss((data["hit"].ox, data["hit"].of), y) + self.temp
+        loss = (-1 * self.temp).exp() * self.loss(data, y) + self.temp
 
         # calculate metrics
         metrics = {}

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -90,7 +90,7 @@ class InstanceDecoder(nn.Module):
                 }
                 data = Batch.from_data_list([self.materialize(b) for b in data.to_data_list()])
             else:
-                self.instance_decoder.materialize(data)
+                self.materialize(data)
 
             # collapse instance edges into labels
             e = data["hit", "cluster", "particle"]
@@ -99,8 +99,9 @@ class InstanceDecoder(nn.Module):
             instances[~mask] = -1
             instances[mask] = e.edge_index[1, instances[mask]]
             data["hit"].i = instances
-            data._slice_dict["hit"]["i"] = data["hit"].ptr
-            data._inc_dict["hit"]["i"] = data._inc_dict["hit"]["x"]
+            if isinstance(data, Batch):
+                data._slice_dict["hit"]["i"] = data["hit"].ptr
+                data._inc_dict["hit"]["i"] = data._inc_dict["hit"]["x"]
 
         # calculate loss
         y = torch.full_like(data["hit"].y_semantic, -1)

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -19,12 +19,14 @@ class InstanceDecoder(nn.Module):
     Args:
         hit_features: Number of hit node features
         instance_features: Number of instance features
+        s_b: Background suppression hyperparameter
     """
-    def __init__(self, hit_features: int, instance_features: int):
+    def __init__(self, hit_features: int, instance_features: int,
+                 s_b: float = 0.1):
         super().__init__()
 
         # loss function
-        self.loss = ObjCondensationLoss()
+        self.loss = ObjCondensationLoss(s_b=s_b)
 
         # Adjusted Rand Index metric
         self.rand = AdjustedRandScore()

--- a/nugraph/nugraph/models/nugraph3/decoders/instance.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/instance.py
@@ -32,7 +32,7 @@ class InstanceDecoder(nn.Module):
         self.rand = AdjustedRandScore()
 
         # temperature parameter
-        self.temp = nn.Parameter(torch.tensor([0., 0.]))
+        self.temp = nn.Parameter(torch.tensor(0.))
 
         # network
         self.beta_net = nn.Linear(hit_features, 1)
@@ -130,8 +130,7 @@ class InstanceDecoder(nn.Module):
                 metrics[f"instance/adjusted-rand-{stage}"] = self.rand(x, y)
 
         if stage == "train":
-            metrics["temperature/instance-bkg"] = self.temp[0]
-            metrics["temperature/instance-potential"] = self.temp[1]
+            metrics["temperature/instance"] = self.temp
 
         return loss, metrics
 

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -108,10 +108,6 @@ class NuGraph3(LightningModule):
         if not self.decoders:
             raise RuntimeError('At least one decoder head must be enabled!')
 
-        # metrics
-        self.max_mem_cpu = 0.
-        self.max_mem_gpu = 0.
-
     def forward(self, data: Data,
                 stage: str = None):
         """

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -49,6 +49,7 @@ class NuGraph3(LightningModule):
                  semantic_head: bool = True,
                  filter_head: bool = True,
                  vertex_head: bool = False,
+                 s_b: float = 0.1,
                  instance_head: bool = False,
                  use_checkpointing: bool = False,
                  lr: float = 0.001):
@@ -77,21 +78,15 @@ class NuGraph3(LightningModule):
         self.decoders = []
 
         if event_head:
-            self.event_decoder = EventDecoder(
-                interaction_features,
-                event_classes)
+            self.event_decoder = EventDecoder(interaction_features, event_classes)
             self.decoders.append(self.event_decoder)
 
         if semantic_head:
-            self.semantic_decoder = SemanticDecoder(
-                hit_features,
-                semantic_classes)
+            self.semantic_decoder = SemanticDecoder(hit_features, semantic_classes)
             self.decoders.append(self.semantic_decoder)
 
         if filter_head:
-            self.filter_decoder = FilterDecoder(
-                hit_features,
-            )
+            self.filter_decoder = FilterDecoder(hit_features,)
             self.decoders.append(self.filter_decoder)
 
         if vertex_head:
@@ -99,10 +94,7 @@ class NuGraph3(LightningModule):
             self.decoders.append(self.vertex_decoder)
 
         if instance_head:
-            self.instance_decoder = InstanceDecoder(
-                hit_features,
-                instance_features,
-            )
+            self.instance_decoder = InstanceDecoder(hit_features, instance_features, s_b)
             self.decoders.append(self.instance_decoder)
 
         if not self.decoders:
@@ -211,6 +203,8 @@ class NuGraph3(LightningModule):
                            help='Enable instance segmentation head')
         model.add_argument('--vertex', action='store_true',
                            help='Enable vertex regression head')
+        model.add_argument("--s-b", type=float, default=0.1,
+                           help="Background suppression hyperparameter for object condensation")
         model.add_argument('--no-checkpointing', action='store_false',
                            dest="use_checkpointing",
                            help='Disable checkpointing during training')
@@ -242,6 +236,7 @@ class NuGraph3(LightningModule):
             semantic_head=args.semantic,
             filter_head=args.filter,
             vertex_head=args.vertex,
+            s_b=args.s_b,
             instance_head=args.instance,
             use_checkpointing=args.use_checkpointing,
             lr=args.learning_rate)

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -2,10 +2,8 @@
 import argparse
 import warnings
 
-import torch
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import OneCycleLR
-from torch_geometric.data import Batch
 
 from pytorch_lightning import LightningModule
 

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -49,7 +49,7 @@ class NuGraph3(LightningModule):
                  semantic_head: bool = True,
                  filter_head: bool = True,
                  vertex_head: bool = False,
-                 s_b: float = 0.1,
+                 s_b: float = 1.0,
                  instance_head: bool = False,
                  use_checkpointing: bool = False,
                  lr: float = 0.001):
@@ -203,7 +203,7 @@ class NuGraph3(LightningModule):
                            help='Enable instance segmentation head')
         model.add_argument('--vertex', action='store_true',
                            help='Enable vertex regression head')
-        model.add_argument("--s-b", type=float, default=0.1,
+        model.add_argument("--s-b", type=float, default=1.0,
                            help="Background suppression hyperparameter for object condensation")
         model.add_argument('--no-checkpointing', action='store_false',
                            dest="use_checkpointing",

--- a/nugraph/nugraph/models/nugraph3/types.py
+++ b/nugraph/nugraph/models/nugraph3/types.py
@@ -6,3 +6,9 @@ TDD = dict[str, TD] # double nested tensor dictionary
 EK = tuple[str, str, str] # edge key
 ED = dict[EK, T] # edge dictionary
 Data = HeteroData | Batch # graph data object
+
+# data interface labels
+N_IT = "particle-truth" # true instance node store
+N_IP = "particle" # predicted instance node store
+E_H_IT = ("hit", "cluster-truth", N_IT) # hit to true instance edges
+E_H_IP = ("hit", "cluster", N_IP) # hit to predicted instance edges

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -18,7 +18,10 @@ class ObjCondensationLoss(torch.nn.Module):
             L_beta_1 = (1 - beta_ak).sum() / K
         else:
             L_beta_1 = 0
-        L_beta_2 = (self.S_b / N_b) * (n_i * beta).sum()
+        if N_b:
+            L_beta_2 = (self.S_b / N_b) * (n_i * beta).sum()
+        else:
+            L_beta_2 = 0
         L_beta = torch.sum(L_beta_1 + L_beta_2)
         return L_beta
     

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -10,11 +10,14 @@ class ObjCondensationLoss(torch.nn.Module):
     def background_loss(self, beta: Tensor, y: Tensor) -> Tensor:
         K = y.max() + 1
         n_i = (y == -1)
-        M_ik = torch.zeros((y.size(0), K), device=y.device).long()
-        M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
-        beta_ak = (beta[:,None] * M_ik).max(dim=0).values
         N_b = n_i.sum()
-        L_beta_1 = (1 - beta_ak).sum() / K
+        if K:
+            M_ik = torch.zeros((y.size(0), K), device=y.device).long()
+            M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
+            beta_ak = (beta[:,None] * M_ik).max(dim=0).values
+            L_beta_1 = (1 - beta_ak).sum() / K
+        else:
+            L_beta_1 = 0
         L_beta_2 = (self.S_b / N_b) * (n_i * beta).sum()
         L_beta = torch.sum(L_beta_1 + L_beta_2)
         return L_beta
@@ -23,7 +26,8 @@ class ObjCondensationLoss(torch.nn.Module):
         K = y.max() + 1
         n_i = (y == -1)
         M_ik = torch.zeros((y.size(0), K), device=y.device).long()
-        M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
+        if K:
+            M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
         q_i = beta.atanh().square() + self.q_min
         q_max = (q_i[:,None] * M_ik).max(dim=0)
         q_ak = q_max.values

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -13,6 +13,7 @@ class ObjCondensationLoss(torch.nn.Module):
     def forward(self, data: HeteroData, y: Tensor) -> Tensor:
 
         device = data["hit"].x.device
+        dtype = data["hit"].x.dtype
 
         # hit information
         n_hit = data["hit"].num_nodes
@@ -37,7 +38,7 @@ class ObjCondensationLoss(torch.nn.Module):
         # determine which hit is the condensation point for each true instance,
         # and get beta values (f_centers) and hit indices (centers)
         e_h, e_p = e_true
-        f_centers = torch.zeros(n_true, device=device)
+        f_centers = torch.zeros(n_true, dtype=dtype, device=device)
         f_centers, centers = scatter_max(f[e_h], e_p, out=f_centers)
         centers = e_h[centers]
 

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -55,4 +55,4 @@ class ObjCondensationLoss(torch.nn.Module):
         v = torch.where(m_ik, dist, (1 - dist).clamp(0))
         v = ((v * q[centers]).sum(dim=1) * q).sum() / n_hit
 
-        return b1 + b2 + v
+        return torch.stack([b1 + b2, v])

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -10,10 +10,10 @@ class ObjCondensationLoss(torch.nn.Module):
     def background_loss(self, beta: Tensor, y: Tensor) -> Tensor:
         K = y.max() + 1
         n_i = (y == -1)
-        N_b = n_i.sum()
         M_ik = torch.zeros((y.size(0), K), device=y.device).long()
         M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
         beta_ak = (beta[:,None] * M_ik).max(dim=0).values
+        N_b = n_i.sum()
         L_beta_1 = (1 - beta_ak).sum() / K
         L_beta_2 = (self.S_b / N_b) * (n_i * beta).sum()
         L_beta = torch.sum(L_beta_1 + L_beta_2)
@@ -23,8 +23,7 @@ class ObjCondensationLoss(torch.nn.Module):
         K = y.max() + 1
         n_i = (y == -1)
         M_ik = torch.zeros((y.size(0), K), device=y.device).long()
-        if K:
-            M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
+        M_ik[~n_i,:] = torch.nn.functional.one_hot(y[~n_i], num_classes=K)
         q_i = beta.atanh().square() + self.q_min
         q_max = (q_i[:,None] * M_ik).max(dim=0)
         q_ak = q_max.values

--- a/nugraph/nugraph/util/__init__.py
+++ b/nugraph/nugraph/util/__init__.py
@@ -6,4 +6,4 @@ from .PositionFeatures import PositionFeatures
 from .FeatureNorm import FeatureNorm, FeatureNormMetric
 from .hierarchical_edges import HierarchicalEdges
 from .event_labels import EventLabels
-from .scriptutils import configure_device
+from .scriptutils import setup_env, configure_device

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -59,7 +59,7 @@ class HierarchicalEdges(BaseTransform):
                 remap = torch.full((imax,), -1, dtype=torch.long)
                 remap[instances] = torch.arange(instances.size(0))
                 y = remap[y]
-            data["particle-truth"].num_nodes = instances.size(0)
+            data["particle-truth"].x = torch.empty(instances.size(0), 0)
             edges = torch.stack((mask.nonzero().squeeze(1), y), dim=0).long()
             data["hit", "cluster-truth", "particle-truth"].edge_index = edges
             del data["hit"].y_instance

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -56,7 +56,7 @@ class HierarchicalEdges(BaseTransform):
             # remap instances
             imax = instances.max() + 1 if instances.size(0) else 0
             if instances.size(0) != imax:
-                remap = torch.empty(imax, dtype=torch.long).fill_(-1)
+                remap = torch.full((imax,), -1, dtype=torch.long)
                 remap[instances] = torch.arange(instances.size(0))
                 y = remap[y]
             data["particle-truth"].num_nodes = instances.size(0)

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -40,7 +40,7 @@ class HierarchicalEdges(BaseTransform):
         for i, p in enumerate(self.planes):
             data[p].plane = torch.empty_like(data[p].x[:,0], dtype=int).fill_(i)
             data[p].x = torch.cat([data[p].x, data[p].plane.unsqueeze(1)], dim=1)
-        
+
         # merge planar node stores
         for attr in data[self.planes[0]].node_attrs():
             data["hit"][attr] = torch.cat([data[p][attr] for p in self.planes], dim=0)

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -65,7 +65,7 @@ class HierarchicalEdges(BaseTransform):
             del data["hit"].y_instance
 
         # add edges to and from event node
-        data["evt"].num_nodes = 1
+        data["evt"].x = torch.empty((1, 0))
         lo = torch.arange(data["hit"].num_nodes, dtype=torch.long)
         hi = torch.zeros(data["hit"].num_nodes, dtype=torch.long)
         data["hit", "in", "evt"].edge_index = torch.stack((lo, hi), dim=0)

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -53,8 +53,14 @@ class HierarchicalEdges(BaseTransform):
             mask = y != -1
             y = y[mask]
             instances = y.unique()
+            # remap instances
+            imax = instances.max() + 1
+            if instances.size(0) != imax:
+                remap = torch.empty(imax, dtype=torch.long).fill_(-1)
+                remap[instances] = torch.arange(instances.size(0))
+                y = remap[y]
             data["particle-truth"].num_nodes = instances.size(0)
-            edges = torch.stack((mask.nonzero().squeeze(1), instances[y]), dim=0).long()
+            edges = torch.stack((mask.nonzero().squeeze(1), y), dim=0).long()
             data["hit", "cluster-truth", "particle-truth"].edge_index = edges
             del data["hit"].y_instance
 

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -47,6 +47,17 @@ class HierarchicalEdges(BaseTransform):
         for p in self.planes:
             del data[p]
 
+        # add true instance nodes
+        if hasattr(data["hit"], "y_instance"):
+            y = data["hit"].y_instance
+            mask = y != -1
+            y = y[mask]
+            instances = y.unique()
+            data["particle-truth"].num_nodes = instances.size(0)
+            edges = torch.stack((mask.nonzero().squeeze(1), instances[y]), dim=0).long()
+            data["hit", "cluster-truth", "particle-truth"].edge_index = edges
+            del data["hit"].y_instance
+
         # add edges to and from event node
         data["evt"].num_nodes = 1
         lo = torch.arange(data["hit"].num_nodes, dtype=torch.long)

--- a/nugraph/nugraph/util/hierarchical_edges.py
+++ b/nugraph/nugraph/util/hierarchical_edges.py
@@ -54,7 +54,7 @@ class HierarchicalEdges(BaseTransform):
             y = y[mask]
             instances = y.unique()
             # remap instances
-            imax = instances.max() + 1
+            imax = instances.max() + 1 if instances.size(0) else 0
             if instances.size(0) != imax:
                 remap = torch.empty(imax, dtype=torch.long).fill_(-1)
                 remap[instances] = torch.arange(instances.size(0))

--- a/nugraph/nugraph/util/scriptutils.py
+++ b/nugraph/nugraph/util/scriptutils.py
@@ -7,12 +7,12 @@ from pynvml.smi import nvidia_smi
 NUGRAPH_ENV = {
     "sneezy": {
         "NUGRAPH_DIR": "/data/home/$USER/nugraph",
-        "NUGRAPH_DATA": "/data/home/hewesje/data",
+        "NUGRAPH_DATA": "/share/lazy/nugraph",
         "NUGRAPH_LOG": "/data/home/$USER/logs",
     },
     "heimdall": {
         "NUGRAPH_DIR": "/raid/$USER/nugraph",
-        "NUGRAPH_DATA": "/raid/nugraph",
+        "NUGRAPH_DATA": "/share/lazy/nugraph",
         "NUGRAPH_LOG": "/raid/$USER/logs",
     },
 }

--- a/nugraph/nugraph/util/scriptutils.py
+++ b/nugraph/nugraph/util/scriptutils.py
@@ -22,7 +22,7 @@ def setup_env(verbose: bool = True) -> None:
     env_vars = ("NUGRAPH_DIR", "NUGRAPH_DATA", "NUGRAPH_LOG")
     nugraph_env = {var: os.getenv(var) for var in env_vars}
 
-    host = platform.node()
+    host = platform.node().lower()
     if not all(nugraph_env.values()) and host not in NUGRAPH_ENV:
         print(f"Could not detect nugraph environment on host \"{host}\".")
         print(("Please export the NUGRAPH_DIR, NUGRAPH_DATA and NUGRAPH_LOG "

--- a/nugraph/nugraph/util/scriptutils.py
+++ b/nugraph/nugraph/util/scriptutils.py
@@ -1,5 +1,48 @@
+"""Utility functions for scripts and notebooks"""
 import os
+import sys
+import platform
 from pynvml.smi import nvidia_smi
+
+NUGRAPH_ENV = {
+    "sneezy": {
+        "NUGRAPH_DIR": "/data/home/$USER/nugraph",
+        "NUGRAPH_DATA": "/data/home/hewesje/data",
+        "NUGRAPH_LOG": "/data/home/$USER/logs",
+    },
+    "heimdall": {
+        "NUGRAPH_DIR": "/raid/$USER/nugraph",
+        "NUGRAPH_DATA": "/raid/nugraph",
+        "NUGRAPH_LOG": "/raid/$USER/logs",
+    },
+}
+
+def setup_env(verbose: bool = True) -> None:
+    """Configure NuGraph environment automatically"""
+    env_vars = ("NUGRAPH_DIR", "NUGRAPH_DATA", "NUGRAPH_LOG")
+    nugraph_env = {var: os.getenv(var) for var in env_vars}
+
+    host = platform.node()
+    if not all(nugraph_env.values()) and host not in NUGRAPH_ENV:
+        print(f"Could not detect nugraph environment on host \"{host}\".")
+        print(("Please export the NUGRAPH_DIR, NUGRAPH_DATA and NUGRAPH_LOG "
+               "environment variables before running, or add your current "
+               "host to the NUGRAPH_ENV dictionary in "
+               "nugraph/util/scriptutils.py"))
+        exit(1)
+
+    if verbose:
+        print("\nconfiguring nugraph environment:")
+    for var in env_vars:
+        if nugraph_env[var]:
+            if verbose:
+                print(f"  {var:14}(set from env var)  - {nugraph_env[var]}")
+        else:
+            os.environ[var] = os.path.expandvars(NUGRAPH_ENV[host][var])
+            if verbose:
+                print(f"  {var:14}(set from host)     - {os.getenv(var)}")
+    if verbose:
+        print()
 
 def configure_device(cpu: bool = False) -> tuple[str, str | list[int]]:
     if not cpu:
@@ -18,3 +61,4 @@ def configure_device(cpu: bool = False) -> tuple[str, str | list[int]]:
         except:
             pass
     return 'cpu', 'auto'
+

--- a/nugraph/nugraph/util/scriptutils.py
+++ b/nugraph/nugraph/util/scriptutils.py
@@ -1,6 +1,5 @@
 """Utility functions for scripts and notebooks"""
 import os
-import sys
 import platform
 from pynvml.smi import nvidia_smi
 
@@ -45,6 +44,7 @@ def setup_env(verbose: bool = True) -> None:
         print()
 
 def configure_device(cpu: bool = False) -> tuple[str, str | list[int]]:
+    """Automatically select GPU device"""
     if not cpu:
         try:
             # query GPU information using pynvml
@@ -61,4 +61,3 @@ def configure_device(cpu: bool = False) -> tuple[str, str | list[int]]:
         except:
             pass
     return 'cpu', 'auto'
-

--- a/nugraph/nugraph/util/scriptutils.py
+++ b/nugraph/nugraph/util/scriptutils.py
@@ -6,7 +6,7 @@ from pynvml.smi import nvidia_smi
 NUGRAPH_ENV = {
     "sneezy": {
         "NUGRAPH_DIR": "/data/home/$USER/nugraph",
-        "NUGRAPH_DATA": "/share/lazy/nugraph",
+        "NUGRAPH_DATA": "/data/home/hewesje/data",
         "NUGRAPH_LOG": "/data/home/$USER/logs",
     },
     "heimdall": {

--- a/nugraph/pyproject.toml
+++ b/nugraph/pyproject.toml
@@ -15,11 +15,12 @@ classifiers = [
 dependencies = [
     "matplotlib",
     "plotly",
-    "pynuml==24.7.1",
+    "pynuml==24.7.dev1",
     "pynvml",
     "seaborn",
     "torch>=1.12.1",
     "torch-geometric>=2.1.0",
+    "torch-scatter",
     "pytorch-lightning>=1.7.1",
 ]
 dynamic = ["version", "description"]

--- a/numl.yaml
+++ b/numl.yaml
@@ -32,6 +32,7 @@ dependencies:
   - pynuml
   - pynvml
   - pytables
+  - pytest
   - python-kaleido
   - pytorch::pytorch=2.2
   - pytorch-cuda=11.8
@@ -43,4 +44,5 @@ dependencies:
   - torchmetrics
   - uproot
   - vim
+  - wandb
   - zlib

--- a/numl.yaml
+++ b/numl.yaml
@@ -5,7 +5,8 @@ channels:
   - pytorch
   - pyg
   - numl
-dependencies:    
+dependencies:
+  - act
   - automake
   - compilers
   - flit
@@ -22,20 +23,21 @@ dependencies:
   - nugraph
   - numba
   - numexpr>=2.8.0 # temporary fix
+  - numpy<2
   - openblas
   - openssh
   - particle
   - ph5concat
   - pip
   - plotly
-  - pyg=2.5
+  - pyg
   - pynuml
   - pynvml
   - pytables
   - pytest
   - python-kaleido
   - pytorch::pytorch=2.2
-  - pytorch-cuda=11.8
+  - pytorch-cuda
   - pytorch-lightning
   - pytorch-scatter
   - PyYAML

--- a/numl.yaml
+++ b/numl.yaml
@@ -37,6 +37,7 @@ dependencies:
   - pytorch::pytorch=2.2
   - pytorch-cuda=11.8
   - pytorch-lightning
+  - pytorch-scatter
   - PyYAML
   - pyzmq
   - seaborn

--- a/numl.yaml
+++ b/numl.yaml
@@ -1,0 +1,46 @@
+name: numl
+channels:
+  - conda-forge
+  - nvidia
+  - pytorch
+  - pyg
+  - numl
+dependencies:    
+  - automake
+  - compilers
+  - flit
+  - git
+  - h5py=*=*mpich*
+  - htop
+  - ipywidgets
+  - jupyterlab
+  - jupyterlab-plotly-extension
+  - mpi4py
+  - nbstripout
+  - ncdu
+  - ninja
+  - nugraph
+  - numba
+  - numexpr>=2.8.0 # temporary fix
+  - openblas
+  - openssh
+  - particle
+  - ph5concat
+  - pip
+  - plotly
+  - pyg=2.5
+  - pynuml
+  - pynvml
+  - pytables
+  - python-kaleido
+  - pytorch::pytorch=2.2
+  - pytorch-cuda=11.8
+  - pytorch-lightning
+  - PyYAML
+  - pyzmq
+  - seaborn
+  - tensorboard
+  - torchmetrics
+  - uproot
+  - vim
+  - zlib

--- a/pynuml/pynuml/io/file.py
+++ b/pynuml/pynuml/io/file.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from abc import ABC
 from typing import Any, Callable, Dict, List, Tuple
@@ -66,7 +67,7 @@ class File:
         }
 
         # open the input HDF5 file in parallel
-        self._fd = h5py.File(fname, "r", driver='mpio', comm=MPI.COMM_WORLD)
+        self._fd = h5py.File(os.path.expandvars(fname), "r", driver='mpio', comm=MPI.COMM_WORLD)
 
         # check if data partitioning key datasets exists in the file
         if parKey not in self._fd.keys():

--- a/pynuml/pynuml/io/file.py
+++ b/pynuml/pynuml/io/file.py
@@ -74,7 +74,6 @@ class File:
             raise Exception(f'Error: dataset {parKey} is not found in file {fname}!')
 
         # parse the name of data partitioning key
-        import os.path
         self._parTable = os.path.dirname(parKey)
         # remove leading '/'
         if self._parTable[0] == '/': self._parTable = self._parTable[1:]

--- a/pynuml/pynuml/process/hitgraph.py
+++ b/pynuml/pynuml/process/hitgraph.py
@@ -159,6 +159,9 @@ class HitGraphProducer(ProcessorBase):
         hits[self.node_pos] *= self.pos_norm
         data["hit"].pos = torch.tensor(hits[self.node_pos].values).float()
 
+        # plane indices
+        data["hit"].plane = torch.tensor(hits["local_plane"].values, dtype=torch.long)
+
         # node features
         data["hit"].x = torch.tensor(hits[self.node_feats].values).float()
 

--- a/pynuml/tests/test_process.py
+++ b/pynuml/tests/test_process.py
@@ -1,9 +1,12 @@
 """Test pynuml graph processing and plotting"""
 import pynuml
+import nugraph as ng
+
+UBOONE_FILE = "$NUGRAPH_DATA/uboone-opendata/uboone-opendata-e5fac1ac.test.h5"
 
 def test_process_uboone():
     """Test graph processing with MicroBooNE open data release"""
-    f = pynuml.io.File("/raid/nugraph/uboone-opendata/uboone-opendata.evt.h5")
+    f = pynuml.io.File(UBOONE_FILE)
     processor = pynuml.process.HitGraphProducer(
         file=f,
         semantic_labeller=pynuml.labels.StandardLabels(),
@@ -12,7 +15,7 @@ def test_process_uboone():
     plot = pynuml.plot.GraphPlot(
         planes=["u", "v", "y"],
         classes=pynuml.labels.StandardLabels().labels[:-1])
-    f.read_data(0, 100)
+    f.read_data_all()
     evts = f.build_evt()
     for evt in evts:
         _, data = processor(evt)

--- a/pynuml/tests/test_process.py
+++ b/pynuml/tests/test_process.py
@@ -24,24 +24,24 @@ def test_process_uboone():
         plot.plot(data, target='semantic', how='true', filter='show')
         plot.plot(data, target='instance', how='true', filter='true')
 
-def test_process_dune_nutau():
-    """Test graph processing with DUNE beam nutau dataset"""
-    f = pynuml.io.File("/raid/nugraph/dune-nutau/test.evt.h5")
-    processor = pynuml.process.HitGraphProducer(
-        file=f,
-        semantic_labeller=pynuml.labels.StandardLabels(),
-        event_labeller=pynuml.labels.FlavorLabels(),
-        label_position=True)
-    plot = pynuml.plot.GraphPlot(
-        planes=["u", "v", "y"],
-        classes=pynuml.labels.StandardLabels().labels[:-1])
-    f.read_data(0, 100)
-    evts = f.build_evt()
-    for evt in evts:
-        _, data = processor(evt)
-        if not data:
-            continue
-        plot.plot(data, target="filter", how="true", filter="show")
-        plot.plot(data, target='semantic', how='true', filter='show')
-        plot.plot(data, target='instance', how='true', filter='true')
-        plot.plot(data, target="semantic", how="true", filter="show", xyz=True)
+# def test_process_dune_nutau():
+#     """Test graph processing with DUNE beam nutau dataset"""
+#     f = pynuml.io.File("/raid/nugraph/dune-nutau/test.evt.h5")
+#     processor = pynuml.process.HitGraphProducer(
+#         file=f,
+#         semantic_labeller=pynuml.labels.StandardLabels(),
+#         event_labeller=pynuml.labels.FlavorLabels(),
+#         label_position=True)
+#     plot = pynuml.plot.GraphPlot(
+#         planes=["u", "v", "y"],
+#         classes=pynuml.labels.StandardLabels().labels[:-1])
+#     f.read_data(0, 100)
+#     evts = f.build_evt()
+#     for evt in evts:
+#         _, data = processor(evt)
+#         if not data:
+#             continue
+#         plot.plot(data, target="filter", how="true", filter="show")
+#         plot.plot(data, target='semantic', how='true', filter='show')
+#         plot.plot(data, target='instance', how='true', filter='true')
+#         plot.plot(data, target="semantic", how="true", filter="show", xyz=True)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -37,8 +37,6 @@ def configure():
 
 def train(args):
 
-    ng.setup_env()
-
     torch.manual_seed(1)
 
     # Load dataset

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -55,8 +55,7 @@ def train(args):
     else:
         raise Exception('You must pass either the --name and --logdir arguments to start an existing training, or the --resume argument to resume an existing one.')
 
-    logger = pl.loggers.WandbLogger(save_dir=logdir, project=name,
-                                    name=version, version=version)
+    logger = pl.loggers.WandbLogger(save_dir=logdir, project=name, name=version)
 
     callbacks = [
         LearningRateMonitor(logging_interval='step'),

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -2,16 +2,18 @@
 
 import os
 import argparse
+import pathlib
+import signal
+import warnings
+
 import torch
 import pytorch_lightning as pl
 from pytorch_lightning.plugins.environments import SLURMEnvironment
-from pytorch_lightning.callbacks import LearningRateMonitor
+from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 import nugraph as ng
-import signal
 
 torch.set_num_threads(4)
 
-import warnings
 warnings.filterwarnings('ignore', '.*TypedStorage is deprecated.*')
 
 Data = ng.data.H5DataModule
@@ -23,10 +25,8 @@ def configure():
                         help='Training instance name, for logging purposes')
     parser.add_argument('--version', type=str, default=None,
                         help='Training version name, for logging purposes')
-    parser.add_argument('--logdir', type=str, default=None,
-                        help='Output directory to write logs to')
-    parser.add_argument('--resume', type=str, default=None,
-                        help='Checkpoint file to resume training from')
+    parser.add_argument("--project", type=str, default="nugraph3",
+                        help="wandb project to log to")
     parser.add_argument('--profiler', type=str, default=None,
                         help='Enable requested profiler')
     parser = Data.add_data_args(parser)
@@ -35,35 +35,35 @@ def configure():
 
 def train(args):
 
+    ng.setup_env()
+
     torch.manual_seed(1)
 
     # Load dataset
     nudata = Data(args.data_path, batch_size=args.batch_size, 
                   shuffle=args.shuffle, balance_frac=args.balance_frac)
 
-    if args.name is not None and args.logdir is not None and args.resume is None:
-        model = Model.from_args(args, nudata)
-        name = args.name
-        logdir = args.logdir
-        version = args.version
-        os.makedirs(os.path.join(logdir, args.name), exist_ok=True)
-    elif args.resume is not None and args.name is None and args.logdir is None:
-        model = Model.load_from_checkpoint(args.resume)
-        stub = os.path.dirname(os.path.dirname(args.resume))
-        stub, version = os.path.split(stub)
-        logdir, name = os.path.split(stub)
-    else:
-        raise Exception('You must pass either the --name and --logdir arguments to start an existing training, or the --resume argument to resume an existing one.')
+    model = Model.from_args(args, nudata)
 
-    logger = pl.loggers.WandbLogger(save_dir=logdir, project=name, name=version)
+    logdir = pathlib.Path(os.environ["NUGRAPH_LOG"])/args.name
+    logdir.mkdir(parents=True, exist_ok=True)
+    logger = pl.loggers.WandbLogger(save_dir=logdir, project=args.project,
+                                    name=args.name, version=args.version,
+                                    log_model="all")
 
-    callbacks = [
-        LearningRateMonitor(logging_interval='step'),
-    ]
+    # configure callbacks
+    callbacks = []
+    if logger:
+        callbacks.append(LearningRateMonitor(logging_interval='step'))
+    if isinstance(logger, pl.loggers.WandbLogger):
+        callbacks.append(ModelCheckpoint(monitor="loss/val", mode="min"))
 
+    # configure plugins
     plugins = [
         SLURMEnvironment(requeue_signal=signal.SIGUSR1),
     ]
+
+    model = Model.from_args(args, nudata)
 
     accelerator, devices = ng.util.configure_device()
     trainer = pl.Trainer(accelerator=accelerator, devices=devices,
@@ -73,7 +73,7 @@ def train(args):
                          logger=logger, profiler=args.profiler,
                          callbacks=callbacks, plugins=plugins)
 
-    trainer.fit(model, datamodule=nudata, ckpt_path=args.resume)
+    trainer.fit(model, datamodule=nudata)
     trainer.test(datamodule=nudata)
 
 if __name__ == '__main__':


### PR DESCRIPTION
this feature branch overhauls how the instance decoder operates. the original scope of this work was to implement the adjusted Rand score (ARS) metric for clustering, but that work uncovered an issue with how we were performing clustering, so the scope has now expanded out to fixing that issue by redesigning pieces of the workflow

## the issue

after adding code to materialize predicted instance labels and calculate the ARS, i noticed that the model wasn't training well – and in fact, was returning nonsense values for that metric. the ARS metric ranges between -1 and 1 by construction, but we were logging values as extreme as 20. i dug into the code, and realized it was due to an oversight in how we construct the instance truth.

up until now, instance labels have been implemented as an integer tensor for each graph hit. any hits with a label of -1 are background – they do not belong to any instance. foreground hits have a label between 0 and N-1, where N is the number of true instances – so all hits associated with the first instance have a label of 0, all hits associated with the second instance have a label of 1, etc etc.

the oversight in how we batch was that integer labels were not offset between graphs in a batch – so every graph's instance labels started again at 0. since we were calculating object condensation across the batch, this meant that from the loss function's perspective, it looks like all hits from the first instance in every batch were all part of one large instance, and so on. this means the loss function would try to group together hits from completely separate events into the same instance, which obviously makes no sense.

## the solution

i considered two possible solutions:
1. offset instance labels across the batch, so every instance in every graph is distinct
2. calculate object condensation loss independently for each graph in the batch, and take the mean

### offsetting instance labels

PyG offers some simple solutions for offsetting tensors when batching graphs together, and one of those is the "increment dictionary." for each feature attribute, it stores a tensor of integers to add to each graph's tensor values when batching, and to subtract when unbatching. ideally we'd just use this functionality, but the fact that we use `-1` for the background hits complicates this – this mechanism would increment them too, which would make no sense.

instead, i added a transform to the graphs to remove the true instance label tensor on the hits, and instead encode the true instance labels as graph edges. each graph gets an empty node store `particle-truth`, with a number of nodes equal to the number of instances. we then assign the true instance labels as edges – each foreground hit is connected to the node corresponding to its true instance. if a hit doesn't belong to any instance in truth, then it doesn't get an edge. this means we don't have to assign any `-1` values, and so PyG automatically handles offsetting the instance indices across the batch.

when we come to compute the loss, we materialize those edges into a true instance label tensor on the hits. if the graphs are batched, the materialized true instance labels will be correctly offset across the batch – and if they aren't, it won't.

this seems to work really nicely – the model appears to be training very well, but it introduces issues with memory overhead. because we're offsetting instance labels, we now have many more true instance labels in a batch, which causes memory spikes due to the object condensation loss function, which is currently coded up to generate tensors internally with size `[N, K]` where `N` is the number of hits and `K` is the number of true instances. i plan to play around with the implementation of the object condensation loss, and see if we can avoid generating these large tensors. it will probably involve at least one for loop, which will slow things down, but if the alternative is out-of-memory errors, we can probably live with that in the short term.

### unbatched object condensation loss

i also tried unbatching the graphs and calculating the object condensation loss on each one independently, and then taking the mean. i was hoping this would be a better solution, but it didn't work at all. see the following instance loss curves:

<img width="1443" alt="Screenshot 2024-08-23 at 1 22 51 PM" src="https://github.com/user-attachments/assets/4caaa0ca-7a1d-4968-94d5-70bf6470cd0d">

here the orange is the batched object condensation curve with instance labels offset. it appears to be learning well, until it crashes due to an out-of-memory error, as discussed above. by contrast, the other two are with unbatched and average object condensation, trained by itself (green) and in tandem with the semantic and filter decoders (purple). neither of them trains well at all, so clearly the object condensation loss needs to be calculated once over the entire batch.

## other changes

i've also wrapped some other development changes into this branch:

### nugraph environment variables

it's always been irritating to switch between training on different clusters and need to constantly update paths to data files and log directories. i've started to build out a system which defines `NUGRAPH_DIR`, `NUGRAPH_DATA` and `NUGRAPH_LOG` environment variables to point towards standard directories on various hosts, so the code will run on different systems without requiring any modification. if the user exports these environment variables, then they will be used; if not, then at runtime the code will query the system's hostname and attempt to configure them automatically. this system needs to be finalized and propagated to all scripts and notebook before this pull request is merged.

### wandb improvements

i'm working to further improve the wandb logging infrastructure. this is reflected in changes to how and where we write output by default. it also means a change in how resuming an existing model training is implemented, but that part is not finished yet – so again, that will need to be finalized before this PR is merged.