### PR TITLE
bug fix: short circuit if self._seq_cnt is empty

### DIFF
--- a/pynuml/pynuml/io/file.py
+++ b/pynuml/pynuml/io/file.py
@@ -681,8 +681,9 @@ class File:
                     idx_found[group] = False
                     dim = self._seq_cnt[group].shape[0]
 
-                    # check against the min and max of this group's
-                    if idx < self._seq_cnt[group][0, 0] or \
+                    # check against the min and max of this group's seq IDs
+                    if len(self._seq_cnt[group]) <= 0 or \
+                       idx < self._seq_cnt[group][0, 0] or \
                        idx > self._seq_cnt[group][dim-1, 0]:
                         continue
 


### PR DESCRIPTION
When checking if a seq ID is missing, add a checking of whether the self._seq_cnt is empty. Empty self._seq_cnt most likely happens only when calling read_data(), rather than read_data_all()