### PR TITLE
Bug fix: check the array size if is smaller than evt ID requested

### DIFF
--- a/pynuml/pynuml/io/file.py
+++ b/pynuml/pynuml/io/file.py
@@ -691,6 +691,7 @@ class File:
                     if idx == idx_grp[group]:
                         # this is most likely the case when building all graphs
                         # for all events at once
+                        if idx >= dim: continue
                         idx_found[group] = True
                         idx_grp[group] = idx
                     elif idx - idx_grp[group] <= 8:


### PR DESCRIPTION
This PR fixes a missed check for when the size of a table's event_id.seq_cnt is
smaller than the requested event ID.
