### PR TITLE
Manually configure GPU device

### DIFF
--- a/notebooks/inference-time.ipynb
+++ b/notebooks/inference-time.ipynb
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "accelerator, devices = ng.util.configure_device()\n",
+    "accelerator, devices = ng.util.configure_device(0)\n",
     "x = []\n",
     "y = []\n",
     "for i in range(9):\n",
@@ -120,7 +120,7 @@
     "        data_path='/raid/uboone/NuGraph2/NG2-paper.gnn.h5',\n",
     "        batch_size=batch_size,\n",
     "    )\n",
-    "    accelerator, devices = ng.util.configure_device()\n",
+    "    accelerator, devices = ng.util.configure_device(0)\n",
     "    trainer = pl.Trainer(accelerator=accelerator,\n",
     "                         devices=devices, logger=False)\n",
     "    t0 = time.time()\n",

--- a/notebooks/test.ipynb
+++ b/notebooks/test.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "source": [
     "### Declare trainer and run testing\n",
-    "First we set the training device. In the instance that we're in a multi-GPU environment, the code will automatically select the GPU with the most available memory; otherwise, it defaults to CPU training. We then instantiate a PyTorch Lightning trainer that we'll use for testing, and then run the testing stage, which iterates over all batches in the test dataset and prints performance metrics."
+    "First we set the testing device. In order to test with a GPU (recommended), pass an integer specifying the index of the GPU to use to the `configure_device()` function; otherwise, this block defaults to CPU testing. We then instantiate a PyTorch Lightning trainer that we'll use for testing, and then run the testing stage, which iterates over all batches in the test dataset and prints performance metrics."
    ]
   },
   {

--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -128,7 +128,7 @@
    "metadata": {},
    "source": [
     "### Declare trainer and run training\n",
-    "First we set the training device. In the instance that we're in a multi-GPU environment, the code will automatically select the GPU with the most available memory; otherwise, it defaults to CPU training. We then instantiate a PyTorch Lightning trainer that we'll use for training, and then run the training stage, which iterates over all batches in the train and validation datasets to optimise model parameters, writing output metrics to tensorboard."
+    "First we set the training device. To train with a GPU, pass an integer  otherwise, it defaults to CPU training. We then instantiate a PyTorch Lightning trainer that we'll use for training, and then run the training stage, which iterates over all batches in the train and validation datasets to optimise model parameters, writing output metrics to tensorboard."
    ]
   },
   {

--- a/numl.yaml
+++ b/numl.yaml
@@ -36,7 +36,6 @@ dependencies:
   - pyg
   - pylint
   - pynuml
-  - pynvml
   - pytables
   - pytest
   - python-kaleido

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -13,6 +13,8 @@ Model = ng.models.NuGraph3
 
 def configure():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=None,
+                        help="Index of GPU device to test with")
     parser.add_argument('--checkpoint', type=str, required=True,
                         help='Checkpoint file for trained model')
     parser.add_argument('--outfile', type=str, required=True,
@@ -32,7 +34,7 @@ def test(args):
     if os.path.isfile(args.outfile):
         raise Exception(f'file {args.outfile} already exists!')
 
-    accelerator, devices = ng.util.configure_device()
+    accelerator, devices = ng.util.configure_device(args.device)
     trainer = pl.Trainer(accelerator=accelerator, devices=devices,
                          logger=False)
     plot = pynuml.plot.GraphPlot(planes=nudata.planes,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,6 +21,8 @@ Model = ng.models.NuGraph3
 
 def configure():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--device', type=int, default=None,
+                        help="Index of GPU device to train with")
     parser.add_argument('--name', type=str, default=None,
                         help='Training instance name, for logging purposes')
     parser.add_argument('--version', type=str, default=None,
@@ -66,7 +68,7 @@ def train(args):
 
     model = Model.from_args(args, nudata)
 
-    accelerator, devices = ng.util.configure_device()
+    accelerator, devices = ng.util.configure_device(args.device)
     trainer = pl.Trainer(accelerator=accelerator, devices=devices,
                          max_epochs=args.epochs,
                          limit_train_batches=args.limit_train_batches,


### PR DESCRIPTION
In the past, the nugraph code attempted to automatically configure the GPU device to use for training by detecting available devices and selecting the device with the lowest utilization. However, this mechanism only ever really worked well on the Heimdall cluster, and recent changes to the `pynvml` package that was used to perform automatic selection have made this mechanism needlessly compliated. For that reason, this PR removes this functionality, requiring the user to manually select the device they want to use.

The function `nugraph.util.configure_device()` now takes an optional integer argument specifying the index of the GPU device to use. If no argument is passed, nugraph will default to running in CPU only mode. When running training or testing from the command line, the user will need to pass `--device <i>`, where `<i>` is an integer, in order to select a GPU. If this argument is not passed, the script will run on CPU only. The user can see available devices, and their utilization, by running `nvidia-smi` on the command line on most systems.