### PR TITLE
install RAPIDS with pip

### DIFF
--- a/numl.yaml
+++ b/numl.yaml
@@ -4,7 +4,6 @@ channels:
   - nvidia
   - pytorch
   - pyg
-  - rapidsai
   - numl
 dependencies:
   - act
@@ -45,7 +44,6 @@ dependencies:
   - pytorch-scatter
   - PyYAML
   - pyzmq
-  - rapids
   - scikit-learn
   - seaborn
   - tensorboard
@@ -54,3 +52,6 @@ dependencies:
   - vim
   - wandb
   - zlib
+  - pip:
+    - cupy-cuda11x
+    - cuml-cu11


### PR DESCRIPTION
Conda environment dependencies get very complicated when incorporating the `cupy` and `cuml` packages from conda-forge. Until this can be resolved, the environment will install these dependencies with pip after the earlier conda packages have been installed.