### PR TITLE
update numl conda environment

### DIFF
--- a/numl.yaml
+++ b/numl.yaml
@@ -1,14 +1,13 @@
 name: numl
 channels:
   - conda-forge
-  - nvidia
-  - pytorch
-  - pyg
-  - numl
+  - rapidsai
 dependencies:
   - act
   - automake
   - compilers
+  # - cuda-version=11.8 # uncomment this line to manually select a 
+  - cuml
   - flit
   - git
   - gh
@@ -22,26 +21,22 @@ dependencies:
   - nbstripout
   - ncdu
   - ninja
-  - nugraph
   - numba
   - numexpr>=2.8.4 # temporary fix
   - numpy
   - openblas
   - openssh
   - particle
-  - ph5concat
   - pip
   - plotly
-  - pyg
   - pylint
-  - pynuml
   - pytables
   - pytest
   - python-kaleido
-  - pytorch::pytorch=2.4
-  - pytorch-cuda=11
+  - pytorch_geometric
+  - pytorch-gpu
   - pytorch-lightning
-  - pytorch-scatter
+  - pytorch_scatter
   - PyYAML
   - pyzmq
   - scikit-learn
@@ -52,6 +47,3 @@ dependencies:
   - vim
   - wandb
   - zlib
-  - pip:
-    - cupy-cuda11x
-    - cuml-cu11


### PR DESCRIPTION
this PR simplifies the standard NuML conda environment in the following ways:
- PyTorch, CUDA and PyG are installed from `conda-forge`, which removes the need for the `pytorch`, `nvidia` and `pyg` channels.
- `cuml` is installed from the `rapidsai` channel instead of from `pip`
- the NuML packages `ph5concat`, `pynuml` and `nugraph` are no longer installed by default. in a development environment, these tagged packages can collide with development versions, which causes a lot of confusion. it is left to the user to install these packages however they see fit.