### PR TITLE
remove setup_env call from import

### DIFF
--- a/nugraph/nugraph/__init__.py
+++ b/nugraph/nugraph/__init__.py
@@ -4,5 +4,3 @@ __version__ = "24.7.dev1"
 from . import data
 from . import models
 from . import util
-
-util.setup_env()


### PR DESCRIPTION
this mechanism was designed to make configuring source code and data directories easier, but in practice it makes things more difficult everywhere except for a couple of UC GPU clusters. the user is still free to set up and use the nugraph environment variables, but they are no longer a condition for importing the module.