### PR TITLE
reduce number of default instance features to 8

### DIFF
--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -47,7 +47,7 @@ class NuGraph3(LightningModule):
                  hit_features: int = 128,
                  nexus_features: int = 32,
                  interaction_features: int = 32,
-                 instance_features: int = 32,
+                 instance_features: int = 8,
                  semantic_classes: tuple[str] = ('MIP','HIP','shower','michel','diffuse'),
                  event_classes: tuple[str] = ('numu','nue','nc'),
                  num_iters: int = 5,
@@ -201,7 +201,7 @@ class NuGraph3(LightningModule):
                            help='Hidden dimensionality of nexus convolutions')
         model.add_argument('--interaction-feats', type=int, default=32,
                            help='Hidden dimensionality of interaction layer')
-        model.add_argument('--instance-feats', type=int, default=32,
+        model.add_argument('--instance-feats', type=int, default=8,
                            help='Hidden dimensionality of object condensation')
         model.add_argument('--event', action='store_true',
                            help='Enable event classification head')


### PR DESCRIPTION
Will Barrett's tests showed that reducing the number of instance features from 32 to 8 didn't meaningfully change clustering performance, so i'm making that value the default