### PR TITLE
Add apptainer definition file

### DIFF
--- a/numl.def
+++ b/numl.def
@@ -1,0 +1,28 @@
+Bootstrap: docker
+From: ubuntu:22.04
+
+%files
+    numl.yaml /opt/numl.yaml
+
+%post
+    apt-get -y update
+    apt-get -y upgrade
+    apt-get -y install wget
+    wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
+    bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opt/miniforge3
+    rm Miniforge3-$(uname)-$(uname -m).sh
+    . /opt/miniforge3/etc/profile.d/conda.sh
+    conda activate
+    conda env create -f /opt/numl.yaml
+    rm /opt/numl.yaml
+
+%environment
+    . /opt/miniforge3/etc/profile.d/conda.sh
+    conda activate numl
+    export PYTHONPATH=/nugraph/pynuml:/nugraph/nugraph:$PYTHONPATH
+    export NUGRAPH_DIR=/nugraph
+    export NUGRAPH_DATA=/data
+    export NUGRAPH_LOG=/log
+
+%runscript
+    /nugraph/scripts/process.py $@

--- a/numl.def
+++ b/numl.def
@@ -13,12 +13,12 @@ From: ubuntu:22.04
     rm Miniforge3-$(uname)-$(uname -m).sh
     . /opt/miniforge3/etc/profile.d/conda.sh
     conda activate
-    conda env create -f /opt/numl.yaml
+    conda env create -p /opt/numl -f /opt/numl.yaml
     rm /opt/numl.yaml
 
 %environment
     . /opt/miniforge3/etc/profile.d/conda.sh
-    conda activate numl
+    conda activate /opt/numl
     export PYTHONPATH=/nugraph/pynuml:/nugraph/nugraph:$PYTHONPATH
     export NUGRAPH_DIR=/nugraph
     export NUGRAPH_DATA=/data

--- a/numl.yaml
+++ b/numl.yaml
@@ -5,7 +5,6 @@ channels:
   - rapidsai
 dependencies:
   - anywidget
-  # - cuda-version=11.8 # uncomment this line to manually select a 
   - cuml
   - h5py=*=*mpich*
   - matplotlib
@@ -19,9 +18,9 @@ dependencies:
   - pytables
   - pytest
   - python-kaleido
-  - pytorch_geometric
   - pytorch=2.5
   - pytorch-lightning
+  - pytorch_geometric
   - pytorch_scatter
   - PyYAML
   - scikit-learn


### PR DESCRIPTION
this PR adds a definition file that builds a basic apptainer image for the numl environment. added so that @Will-Dallaway0299 can have an apptainer image to run at the Cedar supercomputer cluster