### PR TITLE
minor nugraph3 updates

### DIFF
--- a/nugraph/nugraph/models/nugraph3/encoder.py
+++ b/nugraph/nugraph/models/nugraph3/encoder.py
@@ -1,6 +1,6 @@
 """NuGraph3 encoder"""
 import torch
-from .types import Data
+from pynuml.data import NuGraphData
 from ...util import InputNorm
 
 class Encoder(torch.nn.Module):
@@ -19,19 +19,19 @@ class Encoder(torch.nn.Module):
                  nexus_features: int,
                  interaction_features: int):
         super().__init__()
-        self.planar_net = torch.nn.Sequential(
-            InputNorm(in_features),
-            torch.nn.Linear(in_features, planar_features))
+        self.input_norm = InputNorm(in_features)
+        self.planar_net = torch.nn.Linear(in_features, planar_features)
         self.nexus_features = nexus_features
         self.interaction_features = interaction_features
 
-    def forward(self, data: Data) -> None:
+    def forward(self, data: NuGraphData) -> None:
         """
         NuGraph3 encoder forward pass
         
         Args:
             data: Graph data object
         """
+        data["hit"].x = self.input_norm(data["hit"].x)
         data["hit"].x = self.planar_net(data["hit"].x)
         data["sp"].x = torch.zeros(data["sp"].num_nodes,
                                    self.nexus_features,

--- a/nugraph/nugraph/models/nugraph3/nugraph3.py
+++ b/nugraph/nugraph/models/nugraph3/nugraph3.py
@@ -145,6 +145,10 @@ class NuGraph3(LightningModule):
         self.log_dict(metrics, batch_size=batch.num_graphs)
         return loss
 
+    def on_train_epoch_end(self) -> None:
+        # stop updating running average for feature norm
+        self.encoder.input_norm.update = False
+
     def validation_step(self,
                         batch,
                         batch_idx: int) -> None:

--- a/nugraph/nugraph/util/input_norm.py
+++ b/nugraph/nugraph/util/input_norm.py
@@ -1,10 +1,9 @@
 """Input feature normalization module"""
 import torch
-from pytorch_lightning import LightningModule
 
 P = torch.nn.Parameter
 
-class InputNorm(LightningModule):
+class InputNorm(torch.nn.Module):
     """
     PyTorch module to normalize input features
 
@@ -16,12 +15,12 @@ class InputNorm(LightningModule):
 
         # hold onto the running averages for the mean and variance
         self.norm = torch.nn.ParameterDict({
-            "mean": P(torch.zeros(num_features, device=self.device),
-                      requires_grad=False),
-            "var": P(torch.zeros(num_features, device=self.device),
-                     requires_grad=False),
-            "count": P(torch.zeros(1, device=self.device, dtype=torch.long),
-                       requires_grad=False)})
+            "mean": P(torch.zeros(num_features), requires_grad=False),
+            "var": P(torch.zeros(num_features), requires_grad=False),
+            "count": P(torch.zeros(1, dtype=torch.long), requires_grad=False)})
+
+        # whether to continue updating running averages
+        self.update = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor: # pylint: disable=arguments-differ
         """
@@ -31,8 +30,8 @@ class InputNorm(LightningModule):
             x: Tensor to normalize
         """
 
-        # update running average during first epoch
-        if self.training and not self.current_epoch:
+        # update running average
+        if self.update and self.training:
 
             n1, m1, v1 = self.norm["count"], self.norm["mean"], self.norm["var"]
             n2 = x.shape[0]

--- a/pynuml/pynuml/data/nugraph_data.py
+++ b/pynuml/pynuml/data/nugraph_data.py
@@ -102,6 +102,8 @@ class NuGraphData(HeteroData):
 
         # handle empty node tensors
         for node_type in data.node_types:
+            if node_type == "metadata":
+                continue
             n = data[node_type]
             if n.num_nodes is not None and not hasattr(n, "x"):
                 n.x = torch.empty([n.num_nodes, 0])


### PR DESCRIPTION
silence warnings relating to `num_nodes` for data metadata nodes, which are harmless but annoying. also rework submodules of the NuGraph3 architecture to be `torch.nn.Module` instances instead of `LightningModule` instances, as only the model itself should have that type.